### PR TITLE
Fix build/compile breakage across example projects (DOC-1995)

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -16,7 +16,7 @@
     "expo-status-bar": "~57.0.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-native": "0.86.0",
+    "react-native": "0.86.2",
     "react-native-web": "^0.21.2",
     "react-native-webview": "^13.16.1"
   },

--- a/sdk/go-sdk/.gitignore
+++ b/sdk/go-sdk/.gitignore
@@ -85,5 +85,3 @@ tmp/
 
 
 vendor/
-
-go.sum

--- a/sdk/go-sdk/go.sum
+++ b/sdk/go-sdk/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/payabli/sdk-go v1.0.12 h1:7lXICLHqt3a0TddbK/+7UGZcTw/Yj7Nvq5uLDwQSgHQ=
+github.com/payabli/sdk-go v1.0.12/go.mod h1:qGgUhcT7md4YmTDb1sv0rNRTrgfB115/QxDD9kFRnik=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vue-integration/package.json
+++ b/vue-integration/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-embedded-demo",
+  "name": "vue-embedded-demo",
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/webhooks/php-sdk/composer.lock
+++ b/webhooks/php-sdk/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "768d2ad54424e3a6ef77c1e9baf40275",
+    "content-hash": "ee1cf04ed1281f261b64fb46f9f27c09",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -70,26 +70,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.11.2",
+            "version": "7.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "bf5f35ad4b774b9d7c5766c02035e865e7e3fdab"
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/bf5f35ad4b774b9d7c5766c02035e865e7e3fdab",
-                "reference": "bf5f35ad4b774b9d7c5766c02035e865e7e3fdab",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.11",
+                "guzzlehttp/promises": "^2.5.2",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -97,8 +97,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -178,7 +178,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.11.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
             },
             "funding": [
                 {
@@ -194,20 +194,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-12T21:49:57+00:00"
+            "time": "2026-08-05T19:48:21+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
                 "shasum": ""
             },
             "require": {
@@ -262,7 +262,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.2"
             },
             "funding": [
                 {
@@ -278,20 +278,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-08-05T19:30:54+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.1",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "640e2897bbee822dbc8af761d49e1a29b1f2a6b1"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/640e2897bbee822dbc8af761d49e1a29b1f2a6b1",
-                "reference": "640e2897bbee822dbc8af761d49e1a29b1f2a6b1",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -300,7 +300,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -381,7 +381,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -397,20 +397,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-12T21:50:12+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "payabli/payabli",
-            "version": "1.0.1",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/payabli/sdk-php.git",
-                "reference": "72ab26dd4ff1afb5c669fcb4ae163a32e63fae7e"
+                "reference": "3966d1107d45540035eea75001b39c9a556a47bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/payabli/sdk-php/zipball/72ab26dd4ff1afb5c669fcb4ae163a32e63fae7e",
-                "reference": "72ab26dd4ff1afb5c669fcb4ae163a32e63fae7e",
+                "url": "https://api.github.com/repos/payabli/sdk-php/zipball/3966d1107d45540035eea75001b39c9a556a47bc",
+                "reference": "3966d1107d45540035eea75001b39c9a556a47bc",
                 "shasum": ""
             },
             "require": {
@@ -445,9 +445,9 @@
             ],
             "support": {
                 "issues": "https://github.com/payabli/sdk-php/issues",
-                "source": "https://github.com/payabli/sdk-php/tree/1.0.1"
+                "source": "https://github.com/payabli/sdk-php/tree/1.0.9"
             },
-            "time": "2026-06-11T17:41:10+00:00"
+            "time": "2026-07-28T15:49:30+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -865,16 +865,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -912,7 +912,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -932,7 +932,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1188,16 +1188,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.3",
+            "version": "v5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
                 "shasum": ""
             },
             "require": {
@@ -1256,7 +1256,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
             },
             "funding": [
                 {
@@ -1268,7 +1268,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:49:13+00:00"
+            "time": "2026-07-06T19:11:50+00:00"
         }
     ],
     "packages-dev": [],

--- a/webhooks/ts-sdk/main.ts
+++ b/webhooks/ts-sdk/main.ts
@@ -115,7 +115,7 @@ async function createWebhookNotification(targetBase: string): Promise<void> {
 
   try {
     const res = await client.notification.addNotification({
-      content: { eventType: "ApprovedPayment" },
+      content: { eventType: "approvedpayment" },
       frequency: "untilcancelled",
       method: "web",
       ownerId: OWNER_ID,


### PR DESCRIPTION
## Summary

Maintenance pass over every example project in the repo (DOC-1995) — installed/built/compiled all 21 SDK, webhook, and framework-integration examples to find real gaps, not just style nits. Fixed the ones that actually break for a fresh clone or fail type-checking:

- **`sdk/go-sdk`**: `go build` failed on a fresh clone with `missing go.sum entry` errors because `sdk/go-sdk/.gitignore` explicitly excluded `go.sum`. Removed that line and committed a working `go.sum`.
- **`webhooks/php-sdk`**: `composer install` failed outright (exit 4) — `composer.lock` was pinned to `payabli/payabli` `1.0.1`, which doesn't satisfy the `^1.0.8` constraint in `composer.json`. Ran `composer update` to fix; this also cleared 11 security advisories on a transitively-pinned old `guzzlehttp/guzzle`.
- **`webhooks/ts-sdk`**: `tsc` failed — `eventType: "ApprovedPayment"` no longer matches the current `@payabli/sdk-node` types, which expect the lowercase literal `"approvedpayment"`. Fixed the casing.
- **`react-native`**: `tsc --noEmit` failed on `PayabliEmbeddedWebView.tsx` with a WebView prop-type overload error. Root cause was `react-native` itself being two patch versions behind what the installed Expo SDK (57.0.12) expects (`0.86.0` vs `0.86.2`), not `react-native-webview`. Bumped via `expo install --fix`; confirmed `expo export --platform web` still bundles correctly.
- **`vue-integration`**: `package.json` `name` field was `react-embedded-demo`, copy-pasted from `react-integration`. Fixed to `vue-embedded-demo`.

Every other example (boarding, temp-token, react-integration, sdk/ts-sdk, sdk/cs-sdk, webhooks/cs-sdk, sdk & webhooks go/java/php/py/ruby/rust) installed and built/compiled cleanly with no changes needed.

## Test plan

- [x] `sdk/go-sdk`: `go build ./...` succeeds on a clean checkout
- [x] `webhooks/php-sdk`: `composer install` succeeds, `composer audit` reports no advisories
- [x] `webhooks/ts-sdk`: `tsc --noEmit` passes
- [x] `react-native`: `tsc --noEmit` passes, `expo export --platform web` bundles successfully
- [x] `vue-integration`: `pnpm build` still succeeds after the name change
- [x] All other 16 example projects re-verified to install/build/compile without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)